### PR TITLE
Add semicolon for ACF compatibility

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -16,7 +16,7 @@ component {
 
         binder.map( "MigrationService@cfmigrations" )
             .to( "#moduleMapping#.models.MigrationService" )
-            .initArg( name = "defaultGrammar", ref = "#settings.defaultGrammar#@qb" )
+            .initArg( name = "defaultGrammar", ref = "#settings.defaultGrammar#@qb" );
     }
 
 }


### PR DESCRIPTION
So ModuleConfig.cfc won't crash ACF11.