### PR TITLE
Change defaultGrammar to 'AutoDiscover'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@ modules
 testbox
 
 jmimemagic.log
-
-#IntelliJ
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ modules
 testbox
 
 jmimemagic.log
+
+#IntelliJ
+.idea

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -175,7 +175,7 @@ component singleton accessors="true" {
     }
 
     public boolean function isMigrationTableInstalled() {
-        cfdbinfo( name = "results" type = "Tables", datasource = getDatasource() );
+        cfdbinfo( name = "results", type = "Tables", datasource = getDatasource() );
         for ( var row in results ) {
             if ( row.table_name == "cfmigrations" ) {
                 return true;
@@ -242,7 +242,7 @@ component singleton accessors="true" {
     }
 
     private string function getDateTimeColumnType() {
-        cfdbinfo( name = "results" type = "Version", datasource = getDatasource() );
+        cfdbinfo( name = "results", type = "Version", datasource = getDatasource() );
 
         switch( results.database_productName ) {
             case "PostgreSQL"           : return "TIMESTAMP";

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -3,7 +3,7 @@ component singleton accessors="true" {
     property name="wirebox" inject="wirebox";
     property name="migrationsDirectory";
     property name="datasource";
-    property name="defaultGrammar" default="BaseGrammar";
+    property name="schema" inject="SchemaBuilder@qb";
 
     /**
     * Run the next available migration in the desired direction.
@@ -140,10 +140,6 @@ component singleton accessors="true" {
             return;
         }
 
-        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
-            wirebox.getInstance( "#defaultGrammar#@qb" )
-        );
-
         schema.create( "cfmigrations", function( table ) {
             table.string( "name", 190 ).primaryKey();
             table.datetime( "migration_ran" );
@@ -165,17 +161,10 @@ component singleton accessors="true" {
     }
 
     public void function reset() {
-        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
-            wirebox.getInstance( "#defaultGrammar#@qb" )
-        );
         schema.dropAllObjects( { datasource = getDatasource() } );
     }
 
     public boolean function isMigrationTableInstalled() {
-        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
-            wirebox.getInstance( "#defaultGrammar#@qb" )
-        );
-
         return schema.hasTable( "cfmigrations" );
     }
 
@@ -196,13 +185,7 @@ component singleton accessors="true" {
         var migration = wirebox.getInstance( migrationStruct.componentPath );
         var migrationMethod = migration[ direction ];
 
-        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
-            wirebox.getInstance( "#defaultGrammar#@qb" )
-        );
-
-        var query = wirebox.getInstance( "QueryBuilder@qb" ).setGrammar(
-            wirebox.getInstance( "#defaultGrammar#@qb" )
-        );
+        var query = wirebox.getInstance( "QueryBuilder@qb" );
 
         transaction action="begin" {
             try {

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -3,7 +3,7 @@ component singleton accessors="true" {
     property name="wirebox" inject="wirebox";
     property name="migrationsDirectory";
     property name="datasource";
-    property name="schema" inject="SchemaBuilder@qb";
+    property name="defaultGrammar" default="BaseGrammar";
 
     /**
     * Run the next available migration in the desired direction.
@@ -140,6 +140,10 @@ component singleton accessors="true" {
             return;
         }
 
+        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
+            wirebox.getInstance( "#defaultGrammar#@qb" )
+        );
+
         schema.create( "cfmigrations", function( table ) {
             table.string( "name", 190 ).primaryKey();
             table.datetime( "migration_ran" );
@@ -161,10 +165,17 @@ component singleton accessors="true" {
     }
 
     public void function reset() {
+        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
+            wirebox.getInstance( "#defaultGrammar#@qb" )
+        );
         schema.dropAllObjects( { datasource = getDatasource() } );
     }
 
     public boolean function isMigrationTableInstalled() {
+        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
+            wirebox.getInstance( "#defaultGrammar#@qb" )
+        );
+
         return schema.hasTable( "cfmigrations" );
     }
 
@@ -185,7 +196,13 @@ component singleton accessors="true" {
         var migration = wirebox.getInstance( migrationStruct.componentPath );
         var migrationMethod = migration[ direction ];
 
-        var query = wirebox.getInstance( "QueryBuilder@qb" );
+        var schema = wirebox.getInstance( "SchemaBuilder@qb" ).setGrammar(
+            wirebox.getInstance( "#defaultGrammar#@qb" )
+        );
+
+        var query = wirebox.getInstance( "QueryBuilder@qb" ).setGrammar(
+            wirebox.getInstance( "#defaultGrammar#@qb" )
+        );
 
         transaction action="begin" {
             try {

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -3,7 +3,7 @@ component singleton accessors="true" {
     property name="wirebox" inject="wirebox";
     property name="migrationsDirectory";
     property name="datasource";
-    property name="defaultGrammar" default="BaseGrammar";
+    property name="defaultGrammar" default="AutoDiscover";
 
     /**
     * Run the next available migration in the desired direction.


### PR DESCRIPTION
I found this bug while trying to use the latest versions of cfmigration and qb together. It seemed that cfmigration could only work with qb version 5.1 and broke when using qb version 5.2 or above. I'm using a MySql database and it was putting double quotes around my schema and table name in the SQL statement, which doesn't work.

I found that the MigrationService was overriding the grammar set by the ModuleSetting, which was correct. Once I removed the override, it started using the MySqlGrammar instead of the BaseGrammer, which puts back ticks around the schema and table names and everything works great.

Since the SchemaBuilder is a singleton, I injected it in the properties on top, which reduces some lines of code. Yay!

I also removed the hard coded defaultGrammar property as it was overriding the ModuleConfig settings. I hope this works. There were no tests to run, but my initial trials have been successful.