### PR TITLE
Updated MigrationService.cfc

### DIFF
--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -1,9 +1,9 @@
 component singleton accessors="true" {
 
     property name="wirebox" inject="wirebox";
-    property name="migrationsDirectory";
+    property name="migrationsDirectory" default="/resources/database/migrations";
     property name="datasource";
-    property name="defaultGrammar" default="AutoDiscover";
+    property name="defaultGrammar" default="AutoDiscover@qb";
     property name="schema" default="";
     property name="migrationsTable" default="cfmigrations";
 


### PR DESCRIPTION
I just installed cfmigrations on another site and ran into the same issues.  I cannot get this to run without the changes in this PR.  

I believe that the settings in moduleconfig.cfc are not being applied or they are being applied to the wrong thing, but in any case cfmigrations is not seeing/absorbing them.

This is on Lucee 5.3.5.92 on Windows, but that's probably irrelevant.