### PR TITLE
Make logMigration method public

### DIFF
--- a/models/QBMigrationManager.cfc
+++ b/models/QBMigrationManager.cfc
@@ -92,7 +92,7 @@ component accessors="true" {
      * @direction  Whether to log it as up or down
      * @componentName The component name to log
      */
-    private void function logMigration( direction, componentName ) {
+    public void function logMigration( direction, componentName ) {
         if ( direction == "up" ) {
             queryExecute(
                 "INSERT INTO #getMigrationsTable()# VALUES ( :name, :time )",


### PR DESCRIPTION
There are circumstances where this method may need to be accessed via the migration service, itself, or by retrieving the manager through the service.  This change allows for that.