### PR TITLE
Fixed a small bug where datasource was not set on qb instance when running seeds

### DIFF
--- a/models/IMigrationManager.cfc
+++ b/models/IMigrationManager.cfc
@@ -59,10 +59,6 @@ interface {
      *
      * @invocationPath the component invocation path for the seed
      */
-    public void function runSeed(
-        required string invocationPath,
-        function postProcessHook,
-        function preProcessHook
-    );
+    public void function runSeed( required string invocationPath, function postProcessHook, function preProcessHook );
 
 }

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -175,11 +175,7 @@ component accessors="true" {
         if ( !directoryExists( expandPath( variables.seedsDirectory ) ) ) return this;
 
         findSeeds( argumentCollection = arguments ).each( function( file ) {
-            variables.manager.runSeed(
-                file.componentPath,
-                postProcessHook,
-                preProcessHook
-            );
+            variables.manager.runSeed( file.componentPath, postProcessHook, preProcessHook );
         } );
 
         return this;

--- a/models/QBMigrationManager.cfc
+++ b/models/QBMigrationManager.cfc
@@ -178,12 +178,12 @@ component accessors="true" {
     ) {
         arguments.preProcessHook( invocationPath );
         var seeder = wirebox.getInstance( arguments.invocationPath );
-        
+
         var query = wirebox
             .getInstance( "QueryBuilder@qb" )
             .setGrammar( wirebox.getInstance( defaultGrammar ) )
             .setDefaultOptions( { datasource: getDatasource() } );
-        
+
         $transactioned( function() {
             invoke( seeder, "run", [ query, variables.mockData ] );
         } );

--- a/models/QBMigrationManager.cfc
+++ b/models/QBMigrationManager.cfc
@@ -182,7 +182,7 @@ component accessors="true" {
         var query = wirebox
             .getInstance( "QueryBuilder@qb" )
             .setGrammar( wirebox.getInstance( defaultGrammar ) )
-            .setDefaultOptions( { datasource: getDatasource() } );;
+            .setDefaultOptions( { datasource: getDatasource() } );
         
         $transactioned( function() {
             invoke( seeder, "run", [ query, variables.mockData ] );

--- a/models/QBMigrationManager.cfc
+++ b/models/QBMigrationManager.cfc
@@ -178,7 +178,12 @@ component accessors="true" {
     ) {
         arguments.preProcessHook( invocationPath );
         var seeder = wirebox.getInstance( arguments.invocationPath );
-        var query = wirebox.getInstance( "QueryBuilder@qb" ).setGrammar( wirebox.getInstance( defaultGrammar ) );
+        
+        var query = wirebox
+            .getInstance( "QueryBuilder@qb" )
+            .setGrammar( wirebox.getInstance( defaultGrammar ) )
+            .setDefaultOptions( { datasource: getDatasource() } );;
+        
         $transactioned( function() {
             invoke( seeder, "run", [ query, variables.mockData ] );
         } );


### PR DESCRIPTION
I manually set the datasource for my migrationService. This works for running migrations but not seeds. I fixed a small bug where the datasource was not set for the qb instance when executing a seed.

```
var migrationService = getInstance( "migrationService:#rc.manager#" );		
migrationService.getManager().setDatasource('#rc.datasource#');
migrationService.getManager().setSchema('#rc.datasource#');
```