### PR TITLE
fix: normalize Windows backslashes in migration and seed component paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,3 @@
-# v5.1.2
-## 29 Jul 2026 — 00:00:00 UTC
-
-### fix
-
-+ __MigrationService:__ Normalize Windows backslashes in migration and seed component paths to prevent `ClassNotFoundBoxLangException` on Windows ([d680a1f](https://github.com/coldbox-modules/cfmigrations/commit/d680a1f))
-
-
 # v5.1.1
 ## 06 Apr 2026 — 19:58:21 UTC
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v5.1.2
+## 29 Jul 2026 — 00:00:00 UTC
+
+### fix
+
++ __MigrationService:__ Normalize Windows backslashes in migration and seed component paths to prevent `ClassNotFoundBoxLangException` on Windows ([d680a1f](https://github.com/coldbox-modules/cfmigrations/commit/d680a1f))
+
+
 # v5.1.1
 ## 06 Apr 2026 — 19:58:21 UTC
 

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -312,7 +312,7 @@ component accessors="true" {
                 componentName: componentName,
                 absolutePath: file.directory & "/" & file.name,
                 componentPath: listChangeDelims(
-                    directory & "/" & componentName,
+                    replace( directory, "\", "/", "all" ) & "/" & componentName,
                     ".",
                     "/",
                     false
@@ -389,7 +389,7 @@ component accessors="true" {
                     {
                         "componentName": componentName,
                         "componentPath": listChangeDelims(
-                            variables.seedsDirectory & "/" & componentName,
+                            replace( variables.seedsDirectory, "\", "/", "all" ) & "/" & componentName,
                             ".",
                             "/",
                             false

--- a/models/MigrationService.cfc
+++ b/models/MigrationService.cfc
@@ -389,7 +389,12 @@ component accessors="true" {
                     {
                         "componentName": componentName,
                         "componentPath": listChangeDelims(
-                            replace( variables.seedsDirectory, "\", "/", "all" ) & "/" & componentName,
+                            replace(
+                                variables.seedsDirectory,
+                                "\",
+                                "/",
+                                "all"
+                            ) & "/" & componentName,
                             ".",
                             "/",
                             false


### PR DESCRIPTION
On Windows, makePathRelative() returns paths with backslashes (e.g.
resources\database\migrations\). When concatenated with a forward-slash
separator and passed to listChangeDelims (which only treats / as a
delimiter), the backslashes survive into the component path string,
producing malformed class names like
resources\database\migrations\.2026_06_23_201258_security that BoxLang's
[bx] resolver cannot locate.

Normalize the directory value with replace(..., "\", "/", "all") in both
findAll() and findSeeds() before building componentPath, so the path is
always forward-slash-delimited regardless of OS.